### PR TITLE
Update *.sim.byu.edu certificate

### DIFF
--- a/handel.yml
+++ b/handel.yml
@@ -45,7 +45,7 @@ environments:
         max_tasks: 2
       load_balancer:
         type: https
-        https_certificate: bfd9f3aa-9757-42ea-af88-4565f49a2de6
+        https_certificate: ad9a904d-0640-450b-bf7a-f8bac87e1648
         dns_names:
           - gradstudiesenrollment.sim.byu.edu
         health_check_grace_period: 30


### PR DESCRIPTION
Change to use the *.sim.byu.edu certificate that expires on Feb 18, 2022 instead of the current one that expires Feb 19, 2021